### PR TITLE
Handle missing TF before sim offset initialization

### DIFF
--- a/src/universal_robot/carnicero/scripts/pacific_rim_sim.py
+++ b/src/universal_robot/carnicero/scripts/pacific_rim_sim.py
@@ -47,6 +47,19 @@ class admittance_control_sim(admittance_control):
         self.kdl_jnt_to_jac_solver = PyKDL.ChainJntToJacSolver(chain)
         self.kdl_fk_solver = PyKDL.ChainFkSolverPos_recursive(chain)
 
+    def init_offset_and_latch(self):
+        """Wait for the TF tree before running base initialisation."""
+        if not self.tf_buffer.can_transform(
+            self.base_frame,
+            self.tool_frame,
+            rospy.Time(0),
+            rospy.Duration(5.0),
+        ):
+            raise rospy.ROSException(
+                "Transform %s -> %s not available" % (self.base_frame, self.tool_frame)
+            )
+        super(admittance_control_sim, self).init_offset_and_latch()
+
 
 def main():
     try:


### PR DESCRIPTION
## Summary
- ensure pacific_rim_sim waits for base_link→tool0 transform before latching offsets

## Testing
- `python -m py_compile src/universal_robot/carnicero/scripts/pacific_rim_sim.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'rospy')*

------
https://chatgpt.com/codex/tasks/task_e_68b30e7184208323b3af4bdf82848685