### PR TITLE
Publish sinusoidal right arm positions

### DIFF
--- a/src/universal_robot/carnicero/scripts/right_arm_constant_publisher.py
+++ b/src/universal_robot/carnicero/scripts/right_arm_constant_publisher.py
@@ -1,12 +1,13 @@
 #!/usr/bin/env python
-"""Publishes constant elbow and wrist positions for testing.
+"""Publishes sinusoidal elbow and wrist positions for testing.
 
 This node simulates the topics normally provided by another PC by
-publishing `geometry_msgs/PointStamped` messages with fixed coordinates
-on `/right_arm/elbow` and `/right_arm/wrist`.
+publishing `geometry_msgs/PointStamped` messages with coordinates that vary
+sinusoidally on `/right_arm/elbow` and `/right_arm/wrist`.
 """
+import math
 import rospy
-from geometry_msgs.msg import PointStamped
+from geometry_msgs.msg import Point, PointStamped
 
 
 def main():
@@ -21,19 +22,29 @@ def main():
     elbow_msg.header.frame_id = "base_link"
     wrist_msg.header.frame_id = "base_link"
 
-    # Constant positions expressed in base_link
-    elbow_msg.point.x = 0.4
-    elbow_msg.point.y = 0.0
-    elbow_msg.point.z = 0.3
+    # Parameters for sinusoidal motion
+    elbow_base = Point(0.4, 0.0, 0.3)
+    wrist_base = Point(0.6, 0.0, 0.2)
 
-    wrist_msg.point.x = 0.6
-    wrist_msg.point.y = 0.0
-    wrist_msg.point.z = 0.2
+    amplitude = 0.1
+    frequency = 0.5  # Hz
 
     while not rospy.is_shutdown():
         now = rospy.Time.now()
+        t = now.to_sec()
+
         elbow_msg.header.stamp = now
         wrist_msg.header.stamp = now
+
+        # Update elbow and wrist positions with sinusoidal variations
+        elbow_msg.point.x = elbow_base.x + amplitude * math.sin(2 * math.pi * frequency * t)
+        elbow_msg.point.y = elbow_base.y
+        elbow_msg.point.z = elbow_base.z + amplitude * math.cos(2 * math.pi * frequency * t)
+
+        wrist_msg.point.x = wrist_base.x + amplitude * math.sin(2 * math.pi * frequency * t)
+        wrist_msg.point.y = wrist_base.y
+        wrist_msg.point.z = wrist_base.z + amplitude * math.cos(2 * math.pi * frequency * t)
+
         elbow_pub.publish(elbow_msg)
         wrist_pub.publish(wrist_msg)
         rate.sleep()


### PR DESCRIPTION
## Summary
- generate sinusoidal elbow and wrist positions instead of constants

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'rospy')*

------
https://chatgpt.com/codex/tasks/task_e_68b318d61d588323a4169b7159201f71