### PR TITLE
feat: add velocity controller to Gazebo bringup

### DIFF
--- a/src/universal_robot/ur_gazebo/config/ur30_controllers.yaml
+++ b/src/universal_robot/ur_gazebo/config/ur30_controllers.yaml
@@ -35,6 +35,26 @@ joint_group_eff_controller:
   type: effort_controllers/JointGroupEffortController
   joints: *robot_joints
 
+scaled_pos_joint_traj_controller:
+  type: position_controllers/ScaledJointTrajectoryController
+  joints: *robot_joints
+  constraints:
+    goal_time: 0.6
+    stopped_velocity_tolerance: 0.05
+    shoulder_pan_joint: {trajectory: 0.2, goal: 0.1}
+    shoulder_lift_joint: {trajectory: 0.2, goal: 0.1}
+    elbow_joint: {trajectory: 0.2, goal: 0.1}
+    wrist_1_joint: {trajectory: 0.2, goal: 0.1}
+    wrist_2_joint: {trajectory: 0.2, goal: 0.1}
+    wrist_3_joint: {trajectory: 0.2, goal: 0.1}
+  stop_trajectory_duration: 0.5
+  state_publish_rate: *loop_hz
+  action_monitor_rate: 20
+
+joint_group_vel_controller:
+  type: velocity_controllers/JointGroupVelocityController
+  joints: *robot_joints
+
 pos_joint_traj_controller:
   type: position_controllers/JointTrajectoryController
   joints: *robot_joints

--- a/src/universal_robot/ur_gazebo/launch/ur30_bringup.launch
+++ b/src/universal_robot/ur_gazebo/launch/ur30_bringup.launch
@@ -40,8 +40,8 @@
 
   <!-- Controller configuration -->
   <arg name="controller_config_file" default="$(find ur_gazebo)/config/ur30_controllers.yaml" doc="Config file used for defining the ROS-Control controllers."/>
-  <arg name="controllers" default=" eff_joint_traj_controller" doc="Controllers that are activated by default."/>
-  <arg name="stopped_controllers" default="joint_group_eff_controller" doc="Controllers that are initally loaded, but not started."/>
+  <arg name="controllers" default="joint_state_controller scaled_pos_joint_traj_controller" doc="Controllers that are activated by default."/>
+  <arg name="stopped_controllers" default="joint_group_vel_controller" doc="Controllers that are initally loaded, but not started."/>
 
   <!-- robot_state_publisher configuration -->
   <arg name="tf_prefix" default="" doc="tf_prefix used for the robot."/>


### PR DESCRIPTION
## Summary
- add definitions for `scaled_pos_joint_traj_controller` and `joint_group_vel_controller`
- start `joint_state_controller` and `scaled_pos_joint_traj_controller` by default and load velocity controller

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'rospy')*


------
https://chatgpt.com/codex/tasks/task_e_68b321f3796c832380b22514af0fe971