### PR TITLE
Fix UR30 Gazebo start pose and adjust topic names for namespace support

### DIFF
--- a/src/universal_robot/carnicero/scripts/pacific_rim.py
+++ b/src/universal_robot/carnicero/scripts/pacific_rim.py
@@ -49,9 +49,9 @@ class admittance_control(object):
         self.tf_buffer = tf2_ros.Buffer()
         self.tf_listener = tf2_ros.TransformListener(self.tf_buffer)
 
-        rospy.Subscriber('/right_arm/elbow', PointStamped, self.elbow_cb)
-        rospy.Subscriber('/right_arm/wrist', PointStamped, self.wrist_cb)
-        rospy.Subscriber("/joint_states", JointState, self.joint_state_cb)
+        rospy.Subscriber('right_arm/elbow', PointStamped, self.elbow_cb)
+        rospy.Subscriber('right_arm/wrist', PointStamped, self.wrist_cb)
+        rospy.Subscriber('joint_states', JointState, self.joint_state_cb)
 
         self.joint_state = None
         self.wrist_real = None
@@ -93,7 +93,7 @@ class admittance_control(object):
         self.joint_names = ['shoulder_pan_joint','shoulder_lift_joint','elbow_joint',
                             'wrist_1_joint','wrist_2_joint','wrist_3_joint']
 
-        self.joint_vel_pub = rospy.Publisher('/joint_group_vel_controller/command',
+        self.joint_vel_pub = rospy.Publisher('joint_group_vel_controller/command',
                                              Float64MultiArray, queue_size=1)
 
         self.last_pose_real = None
@@ -177,9 +177,9 @@ class admittance_control(object):
 
     # ------------------ switch contrôleurs ------------------
     def switch_controllers(self, start_list, stop_list):
-        rospy.wait_for_service('/controller_manager/switch_controller')
+        rospy.wait_for_service('controller_manager/switch_controller')
         try:
-            switch_controller = rospy.ServiceProxy('/controller_manager/switch_controller', SwitchController)
+            switch_controller = rospy.ServiceProxy('controller_manager/switch_controller', SwitchController)
             resp = switch_controller(start_controllers=start_list, stop_controllers=stop_list, strictness=1)
             return resp.ok
         except Exception as e:

--- a/src/universal_robot/carnicero/scripts/right_arm_constant_publisher.py
+++ b/src/universal_robot/carnicero/scripts/right_arm_constant_publisher.py
@@ -14,8 +14,8 @@ from geometry_msgs.msg import Point, PointStamped
 
 def main():
     rospy.init_node("right_arm_constant_publisher")
-    elbow_pub = rospy.Publisher("/right_arm/elbow", PointStamped, queue_size=1)
-    wrist_pub = rospy.Publisher("/right_arm/wrist", PointStamped, queue_size=1)
+    elbow_pub = rospy.Publisher("right_arm/elbow", PointStamped, queue_size=1)
+    wrist_pub = rospy.Publisher("right_arm/wrist", PointStamped, queue_size=1)
 
     rate = rospy.Rate(rospy.get_param("~rate", 50))  # Hz
 

--- a/src/universal_robot/ur_gazebo/launch/inc/ur_control.launch.xml
+++ b/src/universal_robot/ur_gazebo/launch/inc/ur_control.launch.xml
@@ -30,7 +30,7 @@
   <arg name="start_gazebo" default="true" doc="If true, Gazebo will be started. If false, Gazebo will be assumed to have been started elsewhere." />
 
   <!--Setting initial configuration -->
-  <arg name="initial_joint_positions" default=" -J shoulder_pan_joint 0.0  -J shoulder_lift_joint -1.57 -J elbow_joint 0.0 -J wrist_1_joint -1.57 -J wrist_2_joint 0.0 -J wrist_3_joint 0.0" doc="Initial joint configuration of the robot"/>
+  <arg name="initial_joint_positions" default=" -J shoulder_pan_joint 0.0 -J shoulder_lift_joint -1.57 -J elbow_joint 1.57 -J wrist_1_joint -1.57 -J wrist_2_joint 0.0 -J wrist_3_joint 0.0" doc="Initial joint configuration of the robot"/>
 
   <!-- Load controller settings -->
   <rosparam file="$(arg controller_config_file)" command="load"/>


### PR DESCRIPTION
## Summary
- spawn UR30 in a more neutral pose in Gazebo
- make admittance controller and publisher use relative topics for easier namespacing

## Testing
- `python -m py_compile src/universal_robot/carnicero/scripts/right_arm_constant_publisher.py src/universal_robot/carnicero/scripts/pacific_rim.py src/universal_robot/carnicero/scripts/pacific_rim_sim.py`
- `apt-get update` *(fails: repository not signed)*
- `python - <<'PY'\nimport xml.etree.ElementTree as ET\nET.parse('src/universal_robot/ur_gazebo/launch/inc/ur_control.launch.xml')\nprint('XML OK')\nPY`

------
https://chatgpt.com/codex/tasks/task_e_68b5557722688323aee727361b8f27ad