### PR TITLE
Add build configuration for admittance_control_v2 node

### DIFF
--- a/src/universal_robot/carnicero/CMakeLists.txt
+++ b/src/universal_robot/carnicero/CMakeLists.txt
@@ -195,6 +195,9 @@ include_directories(${catkin_INCLUDE_DIRS} ${EIGEN3_INCLUDE_DIRS})
 add_executable(admittance_control_node src/admittance_control.cpp)
 target_link_libraries(admittance_control_node ${catkin_LIBRARIES} ${orocos_kdl_LIBRARIES})
 
+add_executable(admittance_control_v2_node src/admittance_control_v2.cpp)
+target_link_libraries(admittance_control_v2_node ${catkin_LIBRARIES} ${orocos_kdl_LIBRARIES})
+
 add_executable(pacific_rim_cpp src/pacific_rim_cpp.cpp)
 target_link_libraries(pacific_rim_cpp ${catkin_LIBRARIES} ${orocos_kdl_LIBRARIES})
 

--- a/src/universal_robot/carnicero/package.xml
+++ b/src/universal_robot/carnicero/package.xml
@@ -52,12 +52,36 @@
   <build_depend>geometry_msgs</build_depend>
   <build_depend>rospy</build_depend>
   <build_depend>std_msgs</build_depend>
+  <build_depend>roscpp</build_depend>
+  <build_depend>sensor_msgs</build_depend>
+  <build_depend>controller_manager_msgs</build_depend>
+  <build_depend>tf2_ros</build_depend>
+  <build_depend>tf2_geometry_msgs</build_depend>
+  <build_depend>urdf</build_depend>
+  <build_depend>kdl_parser</build_depend>
+  <build_depend>orocos_kdl</build_depend>
   <build_export_depend>geometry_msgs</build_export_depend>
   <build_export_depend>rospy</build_export_depend>
   <build_export_depend>std_msgs</build_export_depend>
+  <build_export_depend>roscpp</build_export_depend>
+  <build_export_depend>sensor_msgs</build_export_depend>
+  <build_export_depend>controller_manager_msgs</build_export_depend>
+  <build_export_depend>tf2_ros</build_export_depend>
+  <build_export_depend>tf2_geometry_msgs</build_export_depend>
+  <build_export_depend>urdf</build_export_depend>
+  <build_export_depend>kdl_parser</build_export_depend>
+  <build_export_depend>orocos_kdl</build_export_depend>
   <exec_depend>geometry_msgs</exec_depend>
   <exec_depend>rospy</exec_depend>
   <exec_depend>std_msgs</exec_depend>
+  <exec_depend>roscpp</exec_depend>
+  <exec_depend>sensor_msgs</exec_depend>
+  <exec_depend>controller_manager_msgs</exec_depend>
+  <exec_depend>tf2_ros</exec_depend>
+  <exec_depend>tf2_geometry_msgs</exec_depend>
+  <exec_depend>urdf</exec_depend>
+  <exec_depend>kdl_parser</exec_depend>
+  <exec_depend>orocos_kdl</exec_depend>
 
 
   <!-- The export tag contains other, unspecified, tags -->


### PR DESCRIPTION
## Summary
- build admittance_control_v2 C++ node and link against catkin and KDL libs
- declare roscpp, sensor, tf, and kdl dependencies for new node

## Testing
- `catkin_make --pkg carnicero` *(fails: command not found)*
- `apt-get update` *(fails: 403 Forbidden, cannot install catkin)*

------
https://chatgpt.com/codex/tasks/task_e_68be946abf5883239ed971635c67c873